### PR TITLE
Configurable exception on missing resource

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,20 +1,36 @@
 <?php
 
 $finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(__DIR__)
-    ->exclude('vendor')
+    ->in('spec')
+    ->in('src')
 ;
+
+PedroTroller\CS\Fixer\Contrib\SingleCommentExpandedFixer::setExpandedComments([
+    '@var',
+]);
 
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
     ->fixers([
         'align_double_arrow',
         'align_equals',
+        'concat_with_spaces',
+        'line_break_between_statements',
+        'logical_not_operators_with_spaces',
         'newline_after_open_tag',
+        'no_empty_comment',
+        'no_useless_return',
         'ordered_use',
+        'php_unit_construct',
+        'php_unit_strict',
         'phpdoc_order',
         'phpspec',
+        'short_array_syntax',
+        'single_comment_expanded',
+        'strict_param',
     ])
     ->addCustomFixer(new PedroTroller\CS\Fixer\Contrib\PhpspecFixer())
+    ->addCustomFixer(new PedroTroller\CS\Fixer\Contrib\LineBreakBetweenStatementsFixer())
+    ->addCustomFixer(new PedroTroller\CS\Fixer\Contrib\SingleCommentExpandedFixer())
     ->finder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ matrix:
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
 
 before_script:
+    - mv $HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini $HOME/xdebug.ini || return 0
+    - composer global require hirak/prestissimo
     - composer update --prefer-source --dev $COMPOSER_FLAGS
 
 script:
-    - bin/phpspec run -fpretty
     - bin/php-cs-fixer --diff --dry-run -v fix
+    - bin/phpspec run -fpretty

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ By default, the Rad Resource Resolver throws a `Symfony\Component\HttpKernel\Exc
 
 ## Configure the exception when the resource is not found
 
-By default, is the resource is required but null, the componant will throw a 404 exception. You can customize this behavior by setting the `on-missing` parameter. Actually, 404, 401 and 403 are supported.
+By default, if the resource is required but null, the component will throw a 404 exception. You can customize this behavior by setting the `on-missing` parameter. Actually, 404, 401 and 403 are supported.
 
 ```yaml
     _resources:
@@ -96,7 +96,8 @@ By default, is the resource is required but null, the componant will throw a 404
             service: app.building.repository
             method: findByCountryAndCityAndActivity
             arguments: [$countryId, $citySlug, "School"]
-            on-missing: 401
+            on-missing:
+                throw: 401
 ```
 
 ## Available resource resolving arguments

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ By default, the Rad Resource Resolver throws a `Symfony\Component\HttpKernel\Exc
             required: false
 ```
 
+## Configure the exception when the resource is not found
+
+By default, is the resource is required but null, the componant will throw a 404 exception. You can customize this behavior by setting the `on-missing` parameter. Actually, 404, 401 and 403 are supported.
+
+```yaml
+    _resources:
+        buildings:
+            service: app.building.repository
+            method: findByCountryAndCityAndActivity
+            arguments: [$countryId, $citySlug, "School"]
+            on-missing: 401
+```
+
 ## Available resource resolving arguments
 
 - URL variables: you have to use the `$` prefix. For example, if your URL is `/products/{products}/` you can access to `product` value by using `$product`.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/routing": "~2.8 || ~3.0"
     },
     "require-dev": {
-        "pedrotroller/php-cs-custom-fixer": "~1.2.1",
+        "pedrotroller/php-cs-custom-fixer": "~1.5.0",
         "phpspec/phpspec": "~2.4"
     },
     "autoload": {

--- a/spec/Knp/Rad/ResourceResolver/EventListener/ResourcesListenerSpec.php
+++ b/spec/Knp/Rad/ResourceResolver/EventListener/ResourcesListenerSpec.php
@@ -12,6 +12,7 @@ use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 class ResourcesListenerSpec extends ObjectBehavior
@@ -170,5 +171,81 @@ class ResourcesListenerSpec extends ObjectBehavior
         $container->addResource('user', null)->shouldBeCalled();
 
         $this->resolveResources($event);
+    }
+
+    function it_throws_a_forbidden_exception_if_the_resource_could_not_be_found(
+        FilterControllerEvent $event,
+        Request $request,
+        ParameterBag $parameterBag,
+        $resolver,
+        $customSyntaxParser,
+        $variableCaster,
+        $container
+    ) {
+        $event->getRequest()->willReturn($request);
+        $request->attributes = $parameterBag;
+        $customPath          = '@app_user_repository::myMethod("myFirstParameter")';
+
+        $resources = [
+            'user' => $customPath,
+        ];
+
+        $parameterBag->get('_resources', [])->willReturn($resources);
+
+        $customSyntaxParser->supports($customPath)->willReturn(true);
+        $customSyntaxParser->parse($customPath)->willReturn([
+            'service'    => 'app_user_repository',
+            'method'     => 'myMethod',
+            'on-missing' => Response::HTTP_FORBIDDEN,
+            'arguments'  => ['myFirstParameter'],
+        ]);
+
+        $resolver
+            ->resolveResource('app_user_repository', 'myMethod', ['myFirstParameter'])
+            ->willReturn(null)
+        ;
+
+        $this
+            ->shouldThrow('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException')
+            ->during('resolveResources', [$event])
+        ;
+    }
+
+    function it_throws_an_unauthorized_exception_if_the_resource_could_not_be_found(
+        FilterControllerEvent $event,
+        Request $request,
+        ParameterBag $parameterBag,
+        $resolver,
+        $customSyntaxParser,
+        $variableCaster,
+        $container
+    ) {
+        $event->getRequest()->willReturn($request);
+        $request->attributes = $parameterBag;
+        $customPath          = '@app_user_repository::myMethod("myFirstParameter")';
+
+        $resources = [
+            'user' => $customPath,
+        ];
+
+        $parameterBag->get('_resources', [])->willReturn($resources);
+
+        $customSyntaxParser->supports($customPath)->willReturn(true);
+        $customSyntaxParser->parse($customPath)->willReturn([
+            'service'    => 'app_user_repository',
+            'method'     => 'myMethod',
+            'on-missing' => Response::HTTP_UNAUTHORIZED,
+            'arguments'  => ['myFirstParameter'],
+        ]);
+
+        $resolver
+            ->resolveResource('app_user_repository', 'myMethod', ['myFirstParameter'])
+            ->willReturn(null)
+        ;
+
+        $this
+            ->shouldThrow('Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException')
+            ->during('resolveResources', [$event])
+        ;
     }
 }

--- a/src/Knp/Rad/ResourceResolver/DependencyInjection/ResourceResolverExtension.php
+++ b/src/Knp/Rad/ResourceResolver/DependencyInjection/ResourceResolverExtension.php
@@ -14,7 +14,7 @@ class ResourceResolverExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
     }
 

--- a/src/Knp/Rad/ResourceResolver/DependencyInjection/ResourceResolverExtension.php
+++ b/src/Knp/Rad/ResourceResolver/DependencyInjection/ResourceResolverExtension.php
@@ -14,7 +14,7 @@ class ResourceResolverExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
     }
 


### PR DESCRIPTION
Improve #33 by adding a `throw` key in the `on-missing` parameter.